### PR TITLE
Fix for spaces in path to npm on windows

### DIFF
--- a/problems/00-install-npm.js
+++ b/problems/00-install-npm.js
@@ -42,7 +42,7 @@ exports.verify = function (args, cb) {
 
   try {
     npm = which.sync('npm')
-    npm = "npm"
+    npm = 'npm'
   } catch (er) {
     console.error('It looks like npm is not installed.')
     return cb(false)

--- a/problems/00-install-npm.js
+++ b/problems/00-install-npm.js
@@ -42,6 +42,7 @@ exports.verify = function (args, cb) {
 
   try {
     npm = which.sync('npm')
+    npm = "npm"
   } catch (er) {
     console.error('It looks like npm is not installed.')
     return cb(false)

--- a/problems/05-login.js
+++ b/problems/05-login.js
@@ -36,7 +36,7 @@ exports.verify = function (args, cb) {
 
   // test who we are with whoami
   var exec = require('child_process').exec
-  var npm = "npm"
+  var npm = 'npm'
   exec(npm + ' whoami', function (er, stdout, stderr) {
     if (er) {
       process.stdout.write(stdout)

--- a/problems/05-login.js
+++ b/problems/05-login.js
@@ -36,7 +36,7 @@ exports.verify = function (args, cb) {
 
   // test who we are with whoami
   var exec = require('child_process').exec
-  var npm = require('which').sync('npm')
+  var npm = "npm"
   exec(npm + ' whoami', function (er, stdout, stderr) {
     if (er) {
       process.stdout.write(stdout)

--- a/problems/06-package-niceties.js
+++ b/problems/06-package-niceties.js
@@ -51,7 +51,7 @@ exports.verify = function (args, cb) {
 
   // make sure we get no warnings 
   var exec = require('child_process').exec
-  var npm = "npm"
+  var npm = 'npm'
   exec(npm + ' i', function (er, stdout, stderr) {
     if (er) {
       process.stdout.write(stdout)

--- a/problems/06-package-niceties.js
+++ b/problems/06-package-niceties.js
@@ -51,7 +51,7 @@ exports.verify = function (args, cb) {
 
   // make sure we get no warnings 
   var exec = require('child_process').exec
-  var npm = require('which').sync('npm')
+  var npm = "npm"
   exec(npm + ' i', function (er, stdout, stderr) {
     if (er) {
       process.stdout.write(stdout)

--- a/problems/07-publish.js
+++ b/problems/07-publish.js
@@ -39,7 +39,7 @@ exports.verify = function (args, cb) {
   var pkg = require(process.cwd() + '/package.json')
   var name = pkg.name
   var exec = require('child_process').exec
-  var npm = require('which').sync('npm')
+  var npm = "npm"
   exec(npm + ' --color=always view ' + name, function (er, stdout, stderr) {
     if (er) {
       process.stderr.write(stderr)

--- a/problems/07-publish.js
+++ b/problems/07-publish.js
@@ -39,7 +39,7 @@ exports.verify = function (args, cb) {
   var pkg = require(process.cwd() + '/package.json')
   var name = pkg.name
   var exec = require('child_process').exec
-  var npm = "npm"
+  var npm = 'npm'
   exec(npm + ' --color=always view ' + name, function (er, stdout, stderr) {
     if (er) {
       process.stderr.write(stderr)


### PR DESCRIPTION
Based on this thread https://github.com/npm/how-to-npm/issues/11 
I have removed the which call from 5,6,7 lessons and called npm directly. 

For Lesson 1 I have left the which test as if npm isn't installed then it's valid.
As it's a sync call I have set npm to be "npm" immediatly after to prevent the issues in 11. 
