### PR TITLE
Fix Problem 00 verify failure in Windows cmd terminal

### DIFF
--- a/problems/00-install-npm.js
+++ b/problems/00-install-npm.js
@@ -28,6 +28,8 @@ var exec = require('child_process').exec
 var node = process.execPath
 var which = require('which')
 var semver = require('semver')
+var os = require('os');
+
 exports.verify = function (args, cb) {
   if (args.join('').toLowerCase() === 'skip') {
     console.log('Ok, if you say so...\n'+
@@ -48,6 +50,10 @@ exports.verify = function (args, cb) {
   }
 
   // figure out what version we have
+    //if on windows, quote the path to npm
+    if (os.type() === 'Windows_NT') {
+        npm = '"' + npm + '"';
+    }
   exec(npm +' --version', function (code, stdout, stderr) {
     var v = ('' + stdout).trim()
     if (code) {


### PR DESCRIPTION
if run how-to-npm in a Windows cmd terminal,  problem 00 verification
fails to find the npm executable.
