### PR TITLE
Quotes npm executable path in version verification

### DIFF
--- a/problems/00-install-npm.js
+++ b/problems/00-install-npm.js
@@ -41,7 +41,7 @@ exports.verify = function (args, cb) {
   var npm
 
   try {
-    npm = which.sync('npm')
+    npm = '"' + which.sync('npm') + '"'
   } catch (er) {
     console.error('It looks like npm is not installed.')
     return cb(false)


### PR DESCRIPTION
Otherwise, verify fails because 

```
'c:\Program' is not recognized as an internal or external command,
operable program or batch file.
```
