### PR TITLE
Publish (steps 8, 10) error fix.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,11 @@ shop.execute = function (args) {
 
 // Copy the registry-assets if they're not already there.
 try {
-  var assetsStat = fs.statSync(shop.datadir + '/registry')
+  var registryPath = shop.datadir + '/registry';
+  if (!fs.existsSync(registryPath)){
+    fs.mkdirSync(registryPath);
+  }
+  var assetsStat = fs.statSync(registryPath)
   if (!assetsStat.isDirectory()) throw 'enotdir'
 } catch (er) {
   rimraf.sync(shop.datadir + '/registry')


### PR DESCRIPTION
I have 403 error on 8 and 10 steps. When i try under debugger, i realize that how-to-npm tried to acess 'registry' folder, but it isn't exist. I added this folder creation code here, and now step 8 works fine for me.
Maybe 'registry' folder has removed from distributive as empty folder.
