### PR TITLE
Update 08-publish.js to ensure publish modules are public.

### DIFF
--- a/problems/08-publish.js
+++ b/problems/08-publish.js
@@ -18,9 +18,11 @@ Not very good.
 Luckily, that is not a problem for npm, because it's very easy for all
 npm users to publish their modules and share them with the world.
 
-Packages get into the registry by using the `npm publish` command.
+Packages get into the registry by using the `npm publish --access=public` command.
 
-Try it now.  There's not much too it.
+Try it now.  There's not much too it. By default scoped modules are private.
+The '--access=public' flag is needed to ensure scoped modules are public. This 
+option will remain set for all subsequent publishes.
 
 (Make sure you're still in the right project directory, though.  If you
 publish something by mistake, you can remove it, but there's no guarantee


### PR DESCRIPTION
This pull request is to update the documentation on item 8. Currently it references using 'npm publish'. Early in the exercise we create a scoped package. By default when a scoped package is published it is private. This requires a paid account.  I assume it is best the ensure a person's first publish be public because it is unlikely they have a paid account. I think we could just inform the user of the '--access=public' flag and avoid the situation. Below is the npm documentation on this subject.

https://docs.npmjs.com/getting-started/scoped-packages#publishing-a-scoped-package
