### PR TITLE
consider windows directory seperator when sorting file name

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -235,7 +235,7 @@ function receivePublishPut (req, res) {
     existing.time.modified = now
 
     try {
-      fs.writeFileSync(tgzFile.replace(/(-\/)@.*?\//, '$1'), att, { encoding: 'base64' })
+      fs.writeFileSync(tgzFile.replace(/(-[\/\\])@.*?[\/\\]/, '$1'), att, { encoding: 'base64' })
     } catch (er) {
       return _500(req, res, er)
     }

--- a/problems/00-install-npm.js
+++ b/problems/00-install-npm.js
@@ -39,7 +39,7 @@ exports.verify = function (args, cb) {
   var npm
 
   try {
-    npm = "\"" + which.sync('npm') + "\""
+    npm = '"' + which.sync('npm') + '"'
   } catch (er) {
     console.error('It looks like npm is not installed.')
     return cb(false)


### PR DESCRIPTION
publish task is not working on windows as the regular expression expects forward slash for directory separator
