### PR TITLE
escapes the space in image filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i -g how-to-npm
 how-to-npm
 ```
 
-![Workshopper screen](assets/images/Workshopper screen.png)
+![Workshopper screen](assets/images/Workshopper%20screen.png)
 
 This will walk you through the basics of setting up a working
 environment, installing dependencies, logging into npm, publishing a


### PR DESCRIPTION
Escaping the space in the file name makes the image viewable on GitHub.com site. This is(/was previously) displaying the textual version of the Markdown reference:

```
![Workshopper screen](assets/images/Workshopper screen.png)
```